### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -266,7 +266,7 @@ never be called manually, it is only used internally by
 
 #### Associations
 
-Associations provide automated contruction and use of relationships between
+Associations provide automated construction and use of relationships between
 models. To declare an association, create a property with the name of the
 association in the `associations` object inside the `specialization` object
 (examples are available in the test suite in


### PR DESCRIPTION
@janv, I've corrected a typographical error in the documentation of the [kupo](https://github.com/janv/kupo) project. Specifically, I've changed contruction to construction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
